### PR TITLE
requirements.txt get from dev branch not typescript now its merged

### DIFF
--- a/{{cookiecutter.project_shortname}}/requirements.txt
+++ b/{{cookiecutter.project_shortname}}/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/plotly/dash.git@typescript-component-generator#egg=dash[dev]
+git+https://github.com/plotly/dash@dev#egg=dash[dev]
 wheel
 build


### PR DESCRIPTION
Believe this fixes #1 as I had same issue and now its working with these changes. The error before the change:


```
(venv) C:\dev\clients\madetech\gov_uk_dash_components>pip install -r requirements.txt     
Collecting dash[dev]
  Cloning https://github.com/plotly/dash.git (to revision typescript-component-generator) to c:\users\libert~1\appdata\local\temp\pip-install-7c_agz67\dash_11e4957ed35f4091bdc101aef9930efe
  Running command git clone --filter=blob:none --quiet https://github.com/plotly/dash.git 'C:\Users\LIBERT~1\AppData\Local\Temp\pip-install-7c_agz67\dash_11e4957ed35f4091bdc101aef9930efe'
  hint: core.useBuiltinFSMonitor will be deprecated soon; use core.fsmonitor instead
  hint: Disable this message with "git config advice.useCoreFSMonitorConfig false"
  WARNING: Did not find branch or tag 'typescript-component-generator', assuming revision or ref.
  Running command git checkout -q typescript-component-generator
  hint: core.useBuiltinFSMonitor will be deprecated soon; use core.fsmonitor instead
  hint: Disable this message with "git config advice.useCoreFSMonitorConfig false"
  error: pathspec 'typescript-component-generator' did not match any file(s) known to git
  error: subprocess-exited-with-error
  
  × git checkout -q typescript-component-generator did not run successfully.
  │ exit code: 1
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× git checkout -q typescript-component-generator did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```