### PR TITLE
removing extra whitespace in justfile when npm_publish is false

### DIFF
--- a/{{cookiecutter.project_shortname}}/justfile
+++ b/{{cookiecutter.project_shortname}}/justfile
@@ -27,8 +27,8 @@ package: clean build
 
 # Publish the package to pypi using twine.
 publish: package
-    {% if cookiecutter.publish_on_npm %}npm publish{% endif %}
-    twine upload dist/*
+    {% if cookiecutter.publish_on_npm %}npm publish
+    {% endif %}twine upload dist/*
 
 # Remove dist & build directories
 clean:


### PR DESCRIPTION
Fixes https://github.com/plotly/dash-typescript-component-template/issues/18