### PR TITLE
Dash 3 updates

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,8 +2,6 @@
   "project_name": "my dash component",
   "project_shortname": "{{ cookiecutter.project_name.lower()|replace(' ', '_')|replace('-', '_') }}",
   "component_name": "{{ cookiecutter.project_shortname.split('_')|map('capitalize')|join('') }}",
-  "jl_prefix": "",
-  "r_prefix": "",
   "author_name": "Enter your first and last name (For package.json)",
   "author_email": "Enter your email (For package.json)",
   "github_org": "",

--- a/{{cookiecutter.project_shortname}}/README.md
+++ b/{{cookiecutter.project_shortname}}/README.md
@@ -41,11 +41,39 @@ pip install {{cookiecutter.project_shortname}}
 
 ### Publish
 
-If publish on npm:
-```shell
-npm build
-npm publish
+1. Clean up build and  dist - removes old and temp tarballs:
 ```
+rm -rf dist build
+```
+
+
+2. Run a new build
+```
+npm install
+npm run build
+```
+
+2. Build source distribution.  
+```
+npm run dist
+```
+
+3. Test your tarball by copying it into a new environment and installing it locally, for example:
+```
+pip install <your-project-name-version>.tar.gz
+```
+
+Note:  For local install, use  `pip install -e ./path-to-project`
+
+4. Prepare release on the GitHub UI - For more information see [Managing Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+When in doubt, do an alpha release first
+
+5. Publish on PyPI
+```
+$ twine upload dist/*
+```
+
+
 
 ### Justfile
 

--- a/{{cookiecutter.project_shortname}}/README.md
+++ b/{{cookiecutter.project_shortname}}/README.md
@@ -37,9 +37,8 @@ pip install {{cookiecutter.project_shortname}}
    npm run build
    ```
 
-### Component Code
 
-### Publish
+### Create a production build and publish:
 
 1. Clean up build and  dist - removes old and temp tarballs:
 ```
@@ -53,26 +52,36 @@ npm install
 npm run build
 ```
 
-2. Build source distribution.  
+3. Build source distribution.  
 ```
 npm run dist
 ```
 
-3. Test your tarball by copying it into a new environment and installing it locally, for example:
+4. Test your tarball by copying it into a new environment and installing it locally, for example:
 ```
 pip install <your-project-name-version>.tar.gz
 ```
 
-Note:  For local install, use  `pip install -e ./path-to-project`
+Note:  For local install, use:
 
-4. Prepare release on the GitHub UI - For more information see [Managing Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
-When in doubt, do an alpha release first
+```
+pip install -e ./path-to-project
+```
+
 
 5. Publish on PyPI
+
+Prepare release on the GitHub UI - For more information see [Managing Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+When in doubt, do an alpha release first
 ```
 $ twine upload dist/*
 ```
+6. If publish on npm:
 
+Note: Publishing your component to NPM will make the JavaScript bundles available on the unpkg CDN. By default, Dash serves the component library's CSS and JS locally, but if you choose to publish the package to NPM you can set `serve_locally` to `False` and you may see faster load times.
+```
+npm publish
+``` 
 
 
 ### Justfile

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -1,6 +1,6 @@
 {
   "name": "{{cookiecutter.project_shortname}}",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "{{cookiecutter.description}}",
   "main": "index.ts",
 {% if cookiecutter.github_org -%}
@@ -25,10 +25,8 @@
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@types/ramda": "^0.30.1",
     "css-loader": "^6.10.0",
     "npm-run-all": "^4.1.5",
-    "ramda": "^0.30.1",
     "react": "18.2.0",
     "react-docgen": "^5.4.3",
     "react-dom": "18.2.0",

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -18,7 +18,9 @@
     "build:js": "webpack",
     "build:backends": "dash-generate-components ./src/ts/components {{ cookiecutter.project_shortname }} -p package-info.json  --ignore \\.test\\.",
     "build": "npm run build:js && npm run build:backends",
-    "watch": "npm run build:js::dev -- --watch"
+    "watch": "npm run build:js::dev -- --watch",
+    "dist": "python -m build --sdist --wheel --outdir dist/",
+    "format":  "prettier --write src --ignore-path=.prettierignore"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/{{cookiecutter.project_shortname}}/package.json
+++ b/{{cookiecutter.project_shortname}}/package.json
@@ -16,27 +16,30 @@
   "scripts": {
     "build:js::dev": "webpack --mode development",
     "build:js": "webpack",
-    "build:backends": "dash-generate-components ./src/ts/components {{ cookiecutter.project_shortname }} -p package-info.json --r-prefix '{{ cookiecutter.r_prefix }}' --jl-prefix '{{ cookiecutter.jl_prefix }}' --ignore \\.test\\.",
+    "build:backends": "dash-generate-components ./src/ts/components {{ cookiecutter.project_shortname }} -p package-info.json  --ignore \\.test\\.",
     "build": "npm run build:js && npm run build:backends",
     "watch": "npm run build:js::dev -- --watch"
   },
   "devDependencies": {
-    "@types/react": "^17.0.39",
-    "css-loader": "^6.7.1",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@types/ramda": "^0.30.1",
+    "css-loader": "^6.10.0",
     "npm-run-all": "^4.1.5",
-    "ramda": "^0.28.0",
-    "react": "16.13.0",
-    "react-docgen": "^5.4.0",
-    "react-dom": "16.13.0",
-    "style-loader": "^3.3.1",
+    "ramda": "^0.30.1",
+    "react": "18.2.0",
+    "react-docgen": "^5.4.3",
+    "react-dom": "18.2.0",
+    "style-loader": "^3.3.4",
     "ts-loader": "^9.3.1",
-    "typescript": "^4.7.4",
-    "webpack": "^5.73.0",
-    "webpack-cli": "^4.10.0"
+    "typescript": "^5.6.3",
+    "webpack": "^5.101.0",
+    "webpack-cli": "^5.1.4",
+    "prettier": "^3.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "react": "16 - 19",
+    "react-dom": "16- 19"
   },
   "author": "{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>",
   "license": "{% set _license_identifiers = {'MIT License': 'MIT','BSD License': 'BSD','ISC License': 'ISC','Apache Software License 2.0': 'Apache-2.0','GNU General Public License v3': 'GPL-3.0','Not open source': ''} %}{{ _license_identifiers[cookiecutter.license] }}"

--- a/{{cookiecutter.project_shortname}}/requirements.txt
+++ b/{{cookiecutter.project_shortname}}/requirements.txt
@@ -1,3 +1,3 @@
-dash[dev]>=2.5.1
+dash[dev]>=3.0.0
 wheel
 build

--- a/{{cookiecutter.project_shortname}}/src/ts/components/{{cookiecutter.component_name}}.tsx
+++ b/{{cookiecutter.project_shortname}}/src/ts/components/{{cookiecutter.component_name}}.tsx
@@ -17,6 +17,4 @@ const {{cookiecutter.component_name}} = (props: Props) => {
     )
 }
 
-{{cookiecutter.component_name}}.defaultProps = {};
-
 export default {{cookiecutter.component_name}};

--- a/{{cookiecutter.project_shortname}}/usage.py
+++ b/{{cookiecutter.project_shortname}}/usage.py
@@ -1,7 +1,7 @@
 import {{cookiecutter.project_shortname}}
 import dash
 
-app = dash.Dash(__name__)
+app = dash.Dash()
 
 app.layout = {{cookiecutter.project_shortname}}.{{cookiecutter.component_name}}(id='component')
 

--- a/{{cookiecutter.project_shortname}}/usage.py
+++ b/{{cookiecutter.project_shortname}}/usage.py
@@ -7,4 +7,4 @@ app.layout = {{cookiecutter.project_shortname}}.{{cookiecutter.component_name}}(
 
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run(debug=True)


### PR DESCRIPTION
closes #17 
closes #20 
closes #16

- [x] Remove defaultProps from the function component.
- [ ] Add proptypes.js to init
- [x] Change npm react version to 18
- [x] Install dash 3.0 in requirements
- [x] updated usage
- [x] Removed R and Julia 

I didn’t add proptypes.js to init because the build already explains how to include it if you need it. Dash doesn’t handle TypeScript types perfectly yet, but with V4 moving more components to TypeScript, that should get easier soon. In the meantime, developers can choose to add it when it makes sense for their project.

To Do:
- I updated the dependencies, but I'm not sure if they are correct.
- In DMC, the [MANIFEST.in](https://github.com/snehilvj/dash-mantine-components/blob/master/MANIFEST.in) and [tsconfig.json](https://github.com/snehilvj/dash-mantine-components/blob/master/tsconfig.json) have additional info included.  Are those things project specific, or should it be included here too?
- Should setup.py be deleted?